### PR TITLE
Add compatibility with DC-FZ80

### DIFF
--- a/panasonic_camera/camera.py
+++ b/panasonic_camera/camera.py
@@ -167,8 +167,12 @@ class PanasonicCamera:
         # control them. This request adds the current device to the list with
         # a name specified by device_name.
         return self._request(
-            params={'mode': 'accctrl', 'type': 'req_acc', 'value': '0', 'value2': device_name}
-        )
+            params={
+                'mode': 'accctrl',
+                'type': 'req_acc',
+                'value': '0',
+                'value2': device_name
+            })
 
     def start_stream(self, port=49199):
         return self._request(

--- a/panasonic_camera/camera.py
+++ b/panasonic_camera/camera.py
@@ -93,9 +93,6 @@ class PanasonicCamera:
     def _request_xml(self, *args, **kwargs) -> ET.Element:
         kwargs.setdefault('timeout', 2)
         response = requests.get(self.cam_cgi_url, *args, **kwargs)
-        # If this request is trying to register with the camera,
-        # expect a simple text response, not XML. We'll put it
-        # in an XML tag anyway just to keep things tidy.
         camrply: ET.Element = ET.fromstring(response.text)
         self._validate_camrply(camrply)
         return camrply
@@ -166,7 +163,7 @@ class PanasonicCamera:
             states=find_all_text(camrply, 'getstatelist/getstate'),
             specifications=find_all_text(camrply, 'camspeclist/camspec'))
 
-    def register_with_camera(self, device_name='robot-cameraman'):
+    def register_with_camera(self, identify_as: str):
         # Cameras like the DC-FZ80 keep a list of devices that remote
         # control them. This request adds the current device to the list with
         # a name specified by device_name.
@@ -175,7 +172,7 @@ class PanasonicCamera:
                 'mode': 'accctrl',
                 'type': 'req_acc',
                 'value': '0',
-                'value2': device_name
+                'value2': identify_as
             })
 
     def start_stream(self, port=49199):

--- a/panasonic_camera/camera.py
+++ b/panasonic_camera/camera.py
@@ -145,7 +145,7 @@ class PanasonicCamera:
         self._camcmd('wide-fast')
 
     def _get_info(self, info_type: str) -> ET.Element:
-        return self._request(params={'mode': 'getinfo', 'type': info_type})
+        return self._request_xml(params={'mode': 'getinfo', 'type': info_type})
 
     def get_info_capability(self) -> Capability:
         camrply: ET.Element = self._get_info('capability')
@@ -170,7 +170,7 @@ class PanasonicCamera:
         # Cameras like the DC-FZ80 keep a list of devices that remote
         # control them. This request adds the current device to the list with
         # a name specified by device_name.
-        return self._request(
+        return self._request_csv(
             params={
                 'mode': 'accctrl',
                 'type': 'req_acc',
@@ -179,11 +179,11 @@ class PanasonicCamera:
             })
 
     def start_stream(self, port=49199):
-        return self._request(
+        return self._request_xml(
             params={'mode': 'startstream', 'value': port})
 
     def stop_stream(self):
-        return self._request(
+        return self._request_xml(
             params={'mode': 'stopstream'})
 
 

--- a/panasonic_camera/camera.py
+++ b/panasonic_camera/camera.py
@@ -2,13 +2,11 @@ import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from typing import List, Dict, Iterator, Optional
 from urllib.parse import urlparse
-import logging
 
 import requests
 
 from panasonic_camera.discover import discover_panasonic_camera_devices
 
-logger: logging.Logger = logging.getLogger(__name__)
 
 class RejectError(Exception):
     pass
@@ -23,9 +21,13 @@ class CriticalError(Exception):
 
 
 class UnsuitableApp(Exception):
-    logger.error("Camera replied 'unsuitable_app'. If this camera is DC-FZ80 or"
-                 "similar, you probably need to specify the identifyAs "
-                 "parameter so that an accctl request will be sent.")
+    def __init__(self, *args) -> None:
+        self.message = ("Camera replied 'unsuitable_app'. If this camera is"
+                        " DC-FZ80 or similar, you probably need to specify the "
+                        "identifyAs parameter so that an accctl request will be"
+                        " sent.")
+        super().__init__(self.message)
+
 
 @dataclass
 class State:

--- a/panasonic_camera/camera.py
+++ b/panasonic_camera/camera.py
@@ -93,6 +93,11 @@ class PanasonicCamera:
     def _request(self, *args, **kwargs) -> ET.Element:
         kwargs.setdefault('timeout', 2)
         response = requests.get(self.cam_cgi_url, *args, **kwargs)
+        # If this request is trying to register with the camera,
+        # expect a simple text response, not XML. We'll put it
+        # in an XML tag anyway just to keep things tidy.
+        if kwargs['params']['mode'] == 'accctrl' and response.text.startswith('ok'):
+            return ET.Element('camrply', {'reply': response.text})
         camrply: ET.Element = ET.fromstring(response.text)
         self._validate_camrply(camrply)
         return camrply
@@ -156,6 +161,14 @@ class PanasonicCamera:
             settings=settings,
             states=find_all_text(camrply, 'getstatelist/getstate'),
             specifications=find_all_text(camrply, 'camspeclist/camspec'))
+
+    def register_with_camera(self, device_name='robot-cameraman'):
+        # Cameras like the DC-FZ80 keep a list of devices that remote
+        # control them. This request adds the current device to the list with
+        # a name specified by device_name.
+        return self._request(
+            params={'mode': 'accctrl', 'type': 'req_acc', 'value': '0', 'value2': device_name}
+        )
 
     def start_stream(self, port=49199):
         return self._request(

--- a/panasonic_camera/camera_manager.py
+++ b/panasonic_camera/camera_manager.py
@@ -55,8 +55,7 @@ class PanasonicCameraManager(IntervalThread):
             # device (in this case, us) with the camera first.
             if self._identify_as:
                 logger.debug(f'Attempting to identify as {self._identify_as}')
-                self.camera.register_with_camera(
-                    identify_as=self._identify_as)
+                self.camera.register_with_camera(identify_as=self._identify_as)
             # Some cameras like the Panasonic HC-V380 require to get info
             # capability before starting the camera stream
             self.camera.get_info_capability()

--- a/panasonic_camera/camera_manager.py
+++ b/panasonic_camera/camera_manager.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import signal
 from logging import Logger
@@ -18,10 +19,12 @@ logger: Logger = logging.getLogger(__name__)
 
 class PanasonicCameraManager(IntervalThread):
     camera: Optional[PanasonicCamera]
+    _identify_as: Optional[str]
 
     def __init__(self, interval=10, *_args, **_kwargs) -> None:
         super().__init__(interval, self._ensure_connection, *_args, **_kwargs)
         self.camera = None
+        self._identify_as = _kwargs.get('identify_as')
         self.is_stream_started = False
 
     def _ensure_connection(self):
@@ -47,9 +50,13 @@ class PanasonicCameraManager(IntervalThread):
             logger.debug(
                 'Connect to {}: {}'.format(device.friendly_name, hostname))
             self.camera = PanasonicCamera(hostname)
-            # Some cameras like Panasonic DC-FZ80 require registering your
-            # device with the camera first
-            self.camera.register_with_camera()
+            # If we have a _identify_as property, assume this is a camera like
+            # Panasonic DC-FZ80 which requires registering the remote control
+            # device (in this case, us) with the camera first.
+            if self._identify_as:
+                logger.debug(f'Attempting to identify as {self._identify_as}')
+                self.camera.register_with_camera(
+                    identify_as=self._identify_as)
             # Some cameras like the Panasonic HC-V380 require to get info
             # capability before starting the camera stream
             self.camera.get_info_capability()
@@ -84,11 +91,19 @@ class PanasonicCameraManager(IntervalThread):
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--identifyAs', type=str,
+        help="When connecting to the camera for remote control,"
+             " identify ourselves with this name. Required on"
+             "certain cameras including DC-FZ80."
+    )
+    args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG)
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
-    daemon = PanasonicCameraManager()
+    daemon = PanasonicCameraManager(identify_as=args.identifyAs)
     daemon.start()
 
     # https://www.g-loaded.eu/2016/11/24/how-to-terminate-running-python-threads-using-signals/

--- a/panasonic_camera/camera_manager.py
+++ b/panasonic_camera/camera_manager.py
@@ -47,6 +47,9 @@ class PanasonicCameraManager(IntervalThread):
             logger.debug(
                 'Connect to {}: {}'.format(device.friendly_name, hostname))
             self.camera = PanasonicCamera(hostname)
+            # Some cameras like Panasonic DC-FZ80 require registering your
+            # device with the camera first
+            self.camera.register_with_camera()
             # Some cameras like the Panasonic HC-V380 require to get info
             # capability before starting the camera stream
             self.camera.get_info_capability()

--- a/panasonic_camera/camera_manager.py
+++ b/panasonic_camera/camera_manager.py
@@ -93,7 +93,7 @@ class PanasonicCameraManager(IntervalThread):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--identifyAs', type=str,
+        '--identifyToCameraAs', type=str,
         help="When connecting to the camera for remote control,"
              " identify ourselves with this name. Required on"
              "certain cameras including DC-FZ80."
@@ -103,7 +103,7 @@ def main():
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGINT, signal_handler)
 
-    daemon = PanasonicCameraManager(identify_as=args.identifyAs)
+    daemon = PanasonicCameraManager(identify_as=args.identifyToCameraAs)
     daemon.start()
 
     # https://www.g-loaded.eu/2016/11/24/how-to-terminate-running-python-threads-using-signals/

--- a/robot_cameraman/__main__.py
+++ b/robot_cameraman/__main__.py
@@ -60,6 +60,7 @@ class RobotCameramanArguments(Protocol):
     liveView: str
     ip: str
     port: int
+    identifyAs: str
     targetLabelId: int
     output: Path
     font: Path
@@ -122,6 +123,11 @@ def parse_arguments() -> RobotCameramanArguments:
     parser.add_argument('--port', type=int,
                         default=49199,
                         help="UDP Socket port of Panasonic live view.")
+    parser.add_argument('--identifyAs', type=str,
+                        help="When connecting to the camera for remote control,"
+                             " identify ourselves with this name. Required on"
+                             "certain cameras including DC-FZ80."
+                        )
     parser.add_argument('--targetLabelId', type=int,
                         default=0,
                         help="ID of label to track.")
@@ -232,7 +238,7 @@ labels = read_label_file(args.labels)
 font = PIL.ImageFont.truetype(str(args.font), args.fontSize)
 live_view_image_size = ImageSize(args.liveViewWith, args.liveViewHeight)
 destination = Destination(live_view_image_size, variance=args.variance)
-camera_manager = PanasonicCameraManager()
+camera_manager = PanasonicCameraManager(identify_as=args.identifyAs)
 max_speed_and_acceleration_updater = MaxSpeedAndAccelerationUpdater()
 configurable_tracking_strategy = \
     ConfigurableTrackingStrategy(

--- a/robot_cameraman/__main__.py
+++ b/robot_cameraman/__main__.py
@@ -60,7 +60,7 @@ class RobotCameramanArguments(Protocol):
     liveView: str
     ip: str
     port: int
-    identifyAs: str
+    identifyToPanasonicCameraAs: str
     targetLabelId: int
     output: Path
     font: Path
@@ -123,7 +123,7 @@ def parse_arguments() -> RobotCameramanArguments:
     parser.add_argument('--port', type=int,
                         default=49199,
                         help="UDP Socket port of Panasonic live view.")
-    parser.add_argument('--identifyAs', type=str,
+    parser.add_argument('--identifyToPanasonicCameraAs', type=str,
                         help="When connecting to the camera for remote control,"
                              " identify ourselves with this name. Required on"
                              "certain cameras including DC-FZ80."
@@ -238,7 +238,8 @@ labels = read_label_file(args.labels)
 font = PIL.ImageFont.truetype(str(args.font), args.fontSize)
 live_view_image_size = ImageSize(args.liveViewWith, args.liveViewHeight)
 destination = Destination(live_view_image_size, variance=args.variance)
-camera_manager = PanasonicCameraManager(identify_as=args.identifyAs)
+camera_manager = PanasonicCameraManager(
+    identify_as=args.identifyToPanasonicCameraAs)
 max_speed_and_acceleration_updater = MaxSpeedAndAccelerationUpdater()
 configurable_tracking_strategy = \
     ConfigurableTrackingStrategy(


### PR DESCRIPTION
DC-FZ80 requires a little extra initialization to get the "remote controlling" device onto a list that is then accessible in the camera touchscreen UI. This PR adds that initialization.

I tried to write this so it wouldn't break anything for other cameras, but I haven't tested on any cameras besides DC-FZ80.